### PR TITLE
Implement basic app tagging system

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
@@ -7,6 +7,7 @@ import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.home.databinding.DialogRenameItemBinding
 import org.fossify.home.extensions.homeScreenGridItemsDB
 import org.fossify.home.models.HomeScreenGridItem
+import org.fossify.home.helpers.TagStorage
 
 class RenameItemDialog(val activity: Activity, val item: HomeScreenGridItem, val callback: () -> Unit) {
 
@@ -14,6 +15,8 @@ class RenameItemDialog(val activity: Activity, val item: HomeScreenGridItem, val
         val binding = DialogRenameItemBinding.inflate(activity.layoutInflater)
         val view = binding.root
         binding.renameItemEdittext.setText(item.title)
+        val existingTags = TagStorage.getTags(activity, item.packageName)
+        binding.editTags.setText(existingTags.joinToString(", "))
 
         activity.getAlertDialogBuilder()
             .setPositiveButton(org.fossify.commons.R.string.ok, null)
@@ -23,10 +26,14 @@ class RenameItemDialog(val activity: Activity, val item: HomeScreenGridItem, val
                     alertDialog.showKeyboard(binding.renameItemEdittext)
                     alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
                         val newTitle = binding.renameItemEdittext.value
+                        val tags = binding.editTags.text.toString()
+                            .split(",")
+                            .map { it.trim() }
                         if (newTitle.isNotEmpty()) {
                             ensureBackgroundThread {
                                 val result = activity.homeScreenGridItemsDB.updateItemTitle(newTitle, item.id!!)
                                 if (result == 1) {
+                                    TagStorage.saveTags(activity, item.packageName, tags)
                                     callback()
                                     alertDialog.dismiss()
                                 } else {

--- a/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/AllAppsFragment.kt
@@ -25,6 +25,7 @@ import org.fossify.home.activities.MainActivity
 import org.fossify.home.adapters.LaunchersAdapter
 import org.fossify.home.databinding.AllAppsFragmentBinding
 import org.fossify.home.extensions.config
+import org.fossify.home.helpers.TagStorage
 import org.fossify.home.extensions.launchApp
 import org.fossify.home.extensions.setupDrawerBackground
 import org.fossify.home.helpers.ITEM_TYPE_ICON
@@ -240,8 +241,11 @@ class AllAppsFragment(
         binding.searchBar.setupMenu()
 
         binding.searchBar.onSearchTextChangedListener = { query ->
-            val filtered =
-                launchers.filter { query.isEmpty() || it.title.contains(query, ignoreCase = true) }
+            val filtered = launchers.filter { launcher ->
+                query.isEmpty() || launcher.title.contains(query, ignoreCase = true) ||
+                    TagStorage.getTags(context, launcher.packageName)
+                        .any { tag -> tag.contains(query, ignoreCase = true) }
+            }
             getAdapter()?.submitList(filtered) {
                 showNoResultsPlaceholderIfNeeded()
             }

--- a/app/src/main/kotlin/org/fossify/home/helpers/TagStorage.kt
+++ b/app/src/main/kotlin/org/fossify/home/helpers/TagStorage.kt
@@ -1,0 +1,23 @@
+package org.fossify.home.helpers
+
+import android.content.Context
+
+object TagStorage {
+    private const val PREF_NAME = "app_tags"
+
+    fun saveTags(context: Context, packageName: String, tags: List<String>) {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(packageName, tags.joinToString(",")).apply()
+    }
+
+    fun getTags(context: Context, packageName: String): List<String> {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(packageName, "")?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
+    }
+
+    fun searchAppsByTag(context: Context, query: String, allApps: List<org.fossify.home.models.AppLauncher>): List<org.fossify.home.models.AppLauncher> {
+        return allApps.filter {
+            getTags(context, it.packageName).any { tag -> tag.contains(query, ignoreCase = true) }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/home/models/AppTag.kt
+++ b/app/src/main/kotlin/org/fossify/home/models/AppTag.kt
@@ -1,0 +1,6 @@
+package org.fossify.home.models
+
+data class AppTag(
+    val packageName: String,
+    val tags: MutableList<String> = mutableListOf()
+)

--- a/app/src/main/res/layout/dialog_rename_item.xml
+++ b/app/src/main/res/layout/dialog_rename_item.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/rename_item_holder"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:padding="@dimen/activity_margin">
 
     <org.fossify.commons.views.MyTextInputLayout
@@ -19,4 +20,12 @@
             android:textSize="@dimen/bigger_text_size" />
 
     </org.fossify.commons.views.MyTextInputLayout>
-</FrameLayout>
+
+    <EditText
+        android:id="@+id/edit_tags"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Tags (comma-separated)"
+        android:inputType="text" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- support storing tags for apps
- allow editing tags in rename dialog
- filter apps by tag in search
- fix context reference in tag search

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6887d45262988331b7cfefa681e69e52