### PR TITLE
Enable tag editing from app drawer

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/home/dialogs/RenameItemDialog.kt
@@ -29,19 +29,28 @@ class RenameItemDialog(val activity: Activity, val item: HomeScreenGridItem, val
                         val tags = binding.editTags.text.toString()
                             .split(",")
                             .map { it.trim() }
-                        if (newTitle.isNotEmpty()) {
-                            ensureBackgroundThread {
+
+                        if (item.id != null && newTitle.isEmpty()) {
+                            activity.toast(org.fossify.commons.R.string.value_cannot_be_empty)
+                            return@setOnClickListener
+                        }
+
+                        ensureBackgroundThread {
+                            if (item.id != null) {
                                 val result = activity.homeScreenGridItemsDB.updateItemTitle(newTitle, item.id!!)
-                                if (result == 1) {
-                                    TagStorage.saveTags(activity, item.packageName, tags)
-                                    callback()
-                                    alertDialog.dismiss()
-                                } else {
-                                    activity.toast(org.fossify.commons.R.string.unknown_error_occurred)
+                                if (result != 1) {
+                                    activity.runOnUiThread {
+                                        activity.toast(org.fossify.commons.R.string.unknown_error_occurred)
+                                    }
+                                    return@ensureBackgroundThread
                                 }
                             }
-                        } else {
-                            activity.toast(org.fossify.commons.R.string.value_cannot_be_empty)
+
+                            TagStorage.saveTags(activity, item.packageName, tags)
+                            activity.runOnUiThread {
+                                callback()
+                                alertDialog.dismiss()
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/org/fossify/home/extensions/Activity.kt
+++ b/app/src/main/kotlin/org/fossify/home/extensions/Activity.kt
@@ -101,8 +101,13 @@ fun Activity.handleGridItemPopupMenu(
             }
             it.iconTintList = ColorStateList.valueOf(color)
         }
-        menu.findItem(R.id.rename).isVisible =
-            (gridItem.type == ITEM_TYPE_ICON || gridItem.type == ITEM_TYPE_FOLDER) && !isOnAllAppsFragment
+        val renameItem = menu.findItem(R.id.rename)
+        renameItem.isVisible =
+            (gridItem.type == ITEM_TYPE_ICON || gridItem.type == ITEM_TYPE_FOLDER)
+        if (isOnAllAppsFragment) {
+            renameItem.title = getString(R.string.edit_tags)
+        }
+
         menu.findItem(R.id.hide_icon).isVisible =
             gridItem.type == ITEM_TYPE_ICON && isOnAllAppsFragment
         menu.findItem(R.id.resize).isVisible = gridItem.type == ITEM_TYPE_WIDGET

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="double_tap_to_lock">Double tap to lock screen</string>
     <string name="lock_device_admin_hint">To enable the double tap to lock screen feature, you need to grant admin permission. Note that the app cannot be uninstalled until this permission is removed.</string>
     <string name="lock_device_admin_warning">Deactivating admin permission will disable the double tap to lock screen feature.</string>
+    <string name="edit_tags">Edit tags</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
## Summary
- show rename entry (as "Edit tags") in app drawer popup menu
- avoid crash when editing tags for items with null id
- add `edit_tags` string resource

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6887e98f9688833191693468822a8c4b